### PR TITLE
Continue install dog tunnel after apt-get

### DIFF
--- a/scripts/install_ubuntu.sh
+++ b/scripts/install_ubuntu.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # need run as root
 cd ~
-apt-get update && apt-get dist-upgrade -y
-apt-get install tar wget curl git make gcc build-essential -y
+apt-get update && apt-get dist-upgrade -y && echo 'Upgrade system ok'
+apt-get install tar wget curl git make gcc build-essential -y && echo 'package installed'
 mkdir /root/goworkspace
 wget https://storage.googleapis.com/golang/go1.4.linux-amd64.tar.gz
 tar zxvf go1.4.linux-amd64.tar.gz


### PR DESCRIPTION
By default, apt-get will return zero, the bash will exit
If we need run more command after apt-get , we need add this